### PR TITLE
Fix global scope issue + prevent infinite loop

### DIFF
--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -93,6 +93,27 @@ Adlib.prototype.fetchWithNTLM = function(querypath) {
     });
 }
 
+Adlib.prototype.fetchWithNTLM = function(querypath) {
+    console.log("fetching: " + querypath)
+    const self = this;
+    return new Promise((resolve, reject) => {
+        httpntlm.get({
+            url: config.adlib.baseUrl + querypath,
+            username: config.adlib.username,
+            password: config.adlib.password
+        }, function (err, res) {
+            if (err) reject(err);
+            try {
+                if (res && res.body) resolve(JSON.parse(res.body));
+                else self.fetchWithNTLM(querypath); // retry
+            } catch (e) {
+                console.log(`ERROR: ${e.message}`)
+            }
+        });
+    });
+}
+
+
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/lib/adlib.js
+++ b/lib/adlib.js
@@ -76,25 +76,6 @@ Adlib.prototype.fetchWithNTLMRecursively = async function(lastModifiedDate, star
 
 Adlib.prototype.fetchWithNTLM = function(querypath) {
     console.log("fetching: " + querypath)
-    return new Promise((resolve, reject) => {
-        httpntlm.get({
-            url: config.adlib.baseUrl + querypath,
-            username: config.adlib.username,
-            password: config.adlib.password
-        }, function (err, res) {
-            if (err) reject(err);
-            try {
-                if (res && res.body) resolve(JSON.parse(res.body));
-                else this.fetchWithNTLM(querypath); // retry
-            } catch (e) {
-                this.fetchWithNTLM(querypath); // retry
-            }
-        });
-    });
-}
-
-Adlib.prototype.fetchWithNTLM = function(querypath) {
-    console.log("fetching: " + querypath)
     const self = this;
     return new Promise((resolve, reject) => {
         httpntlm.get({


### PR DESCRIPTION
Calling `this.fetchWithNTLM()` from within itself won't work as the `this` keyword references the global scope at that point. This is easily fixed by 'caching' `this` at invocation when it is still scoped to itself. `const self = this;`

Calling the same function on catch will most likely result in an infinite loop as more often then not when catch has been called the error does not resolve by itself. Momentarily just logging the error but this can be replaced by a retry mechanism with max retry limit if this is more appropriate.   

[Note] The else statement of the return statement can also cause an infinite loop

